### PR TITLE
Make channelID in promises unified bytes32 type

### DIFF
--- a/contracts/AccountantImplementation.sol
+++ b/contracts/AccountantImplementation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.12;
 
 import { ECDSA } from "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/ChannelImplementation.sol
+++ b/contracts/ChannelImplementation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.12;
 
 import { ECDSA } from "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/ChannelImplementation.sol
+++ b/contracts/ChannelImplementation.sol
@@ -83,7 +83,7 @@ contract ChannelImplementation is FundsRecovery {
     function settlePromise(uint256 _amount, uint256 _transactorFee, bytes32 _lock, bytes memory _signature) public {
         bytes32 _hashlock = keccak256(abi.encode(_lock));
         address _channelId = address(this);
-        address _signer = keccak256(abi.encodePacked(_channelId, _amount, _transactorFee, _hashlock)).recover(_signature);
+        address _signer = keccak256(abi.encodePacked(uint256(_channelId), _amount, _transactorFee, _hashlock)).recover(_signature);
         require(_signer == operator, "have to be signed by channel operator");
 
         // Calculate amount of tokens to be claimed.

--- a/contracts/DEXProxy.sol
+++ b/contracts/DEXProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.12;
 
 
 contract DEXProxy {

--- a/contracts/FundsRecovery.sol
+++ b/contracts/FundsRecovery.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.12;
 
 import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/contracts/MystDEX.sol
+++ b/contracts/MystDEX.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.12;
 
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/MystToken.sol
+++ b/contracts/MystToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.12;
 
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { ERC20 } from "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.12;
 
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { ECDSA } from "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payments-smart-contracts",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Smart contracts for Mysterium payments flow",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payments-smart-contracts",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "description": "Smart contracts for Mysterium payments flow",
   "main": "index.js",
   "scripts": {

--- a/test/utils/client.js
+++ b/test/utils/client.js
@@ -217,7 +217,7 @@ function generatePromise(amountToPay, fee, channelState, operator) {
 
 function createPromise(channelId, amount, fee, hashlock, operator) {
     const message = Buffer.concat([
-        Buffer.from(channelId.slice(2), 'hex'),  // channelId = channel address
+        toBytes32Buffer(channelId, 'address'),  // channelId = channel address
         toBytes32Buffer(amount),   // total promised amount in this channel
         toBytes32Buffer(fee),      // fee to transfer for msg.sender
         hashlock     // hashlock needed for HTLC scheme
@@ -232,7 +232,7 @@ function createPromise(channelId, amount, fee, hashlock, operator) {
 
 function validatePromise(promise, pubKey) {
     const message = Buffer.concat([
-        Buffer.from(promise.channelId.slice(2), 'hex'),  // channelId = channel address
+        toBytes32Buffer(promise.channelId, 'address'), // channelId = channel address
         toBytes32Buffer(promise.amount),   // total promised amount in this channel
         toBytes32Buffer(promise.fee),      // fee to transfer for msg.sender
         promise.hashlock     // hashlock needed for HTLC scheme

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -91,7 +91,11 @@ async function topUpTokens(token, to, amount) {
     expectedBalance.should.be.bignumber.equal(await token.balanceOf(to))
 }
 
-function toBytes32Buffer(item) {
+function toBytes32Buffer(item, type) {
+    if (type === 'address') {
+        item = new BN(item.replace(/0x/, ''), 16)
+    }
+
     if(typeof item === 'number' || typeof item === 'string') {
         item = new BN(item)
     }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -11,7 +11,7 @@ module.exports = {
     
     compilers: {
         solc: {
-            version: "^0.5.8",
+            version: "^0.5.12",
             settings: {
                 evmVersion: "petersburg"
             }


### PR DESCRIPTION
Make channelID in consumer promise as bytes32 to be unified with provider's promise. Until now we used `Address` type which is bytes20.