### PR TITLE
Various fixes required in TODOs

### DIFF
--- a/contracts/AccountantImplementation.sol
+++ b/contracts/AccountantImplementation.sol
@@ -179,7 +179,7 @@ contract AccountantImplementation is FundsRecovery {
         _channel.settled = _channel.settled.add(_unpaidAmount);
 
         // Calculate accountant fee
-        uint256 _accountantFee = getAccountantFee(_unpaidAmount);
+        uint256 _accountantFee = calculateAccountantFee(_unpaidAmount);
 
         // Transfer tokens and decrease balance
         token.transfer(_channel.beneficiary, _unpaidAmount.sub(_transactorFee).sub(_accountantFee));
@@ -405,8 +405,7 @@ contract AccountantImplementation is FundsRecovery {
         emit AccountantFeeUpdated(_newFee, _validFrom);
     }
 
-    // TODO rename into CalculateAccountantFeeOf(uint256 _amount)
-    function getAccountantFee(uint256 _amount) public view returns (uint256) {
+    function calculateAccountantFee(uint256 _amount) public view returns (uint256) {
         AccountantFee memory _activeFee = (block.number >= lastFee.validFrom) ? lastFee : previousFee;
         return round((_amount * uint256(_activeFee.value) / 100), 100) / 100;
     }

--- a/contracts/ChannelImplementation.sol
+++ b/contracts/ChannelImplementation.sol
@@ -155,15 +155,18 @@ contract ChannelImplementation is FundsRecovery {
     */
 
     // Setting new destination of funds recovery.
-    // TODO: Protect from replly attack
     string constant FUNDS_DESTINATION_PREFIX = "Set funds destination:";
-    function setFundsDestinationByCheque(address payable _newDestination, bytes memory _signature) public {
+    uint256 internal lastNonce;
+    function setFundsDestinationByCheque(address payable _newDestination, uint256 _nonce, bytes memory _signature) public {
         require(_newDestination != address(0));
+        require(_nonce > lastNonce, "nonce have to be bigger than last one");
 
-        address _signer = keccak256(abi.encodePacked(FUNDS_DESTINATION_PREFIX, _newDestination)).recover(_signature);
-        require(_signer == operator, "Have to be signed by proper identity");
+        address _signer = keccak256(abi.encodePacked(FUNDS_DESTINATION_PREFIX, _newDestination, _nonce)).recover(_signature);
+        require(_signer == operator, "bave to be signed by proper identity");
 
         emit DestinationChanged(fundsDestination, _newDestination);
+
         fundsDestination = _newDestination;
+        lastNonce = _nonce;
     }
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -33,7 +33,6 @@ contract Registry is Ownable, FundsRecovery {
     struct Accountant {
         address operator;
         function() external view returns(uint256) stake;
-        // TODO add accountant status: healthy, warning, inactive
     }
     mapping(address => Accountant) public accountants;
 

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -193,12 +193,10 @@ contract Registry is Ownable, FundsRecovery {
         return _codeLength != 0;
     }
 
-    // TODO write test to recheck what will be returned when such accountant is not registered at all
-    function isActiveAccountant(address _accountantId) public view returns (bool) {
+    function isActiveAccountant(address _accountantId) internal view returns (bool) {
         // If stake is 0, then it's either incactive or unregistered accountant
         AccountantContract.Status status = AccountantContract(_accountantId).getStatus();
         return status == AccountantContract.Status.Active;
-        // return accountants[_accountantId].stake() != uint256(0);
     }
 
     function changeRegistrationFee(uint256 _newFee) public onlyOwner {

--- a/test/accountant.js
+++ b/test/accountant.js
@@ -344,7 +344,7 @@ contract('Accountant Contract Implementation tests', ([txMaker, operatorAddress,
         const nonce = new BN(3)
         const signature = signChannelBeneficiaryChange(channelId, newBeneficiary, nonce, identityB)
 
-        await accountant.setBeneficiary(identityB.address, newBeneficiary, nonce, signature)
+        await accountant.setBeneficiary(channelId, newBeneficiary, nonce, signature)
 
         expect((await accountant.channels(channelId)).beneficiary).to.be.equal(newBeneficiary)
     })

--- a/test/accountant.js
+++ b/test/accountant.js
@@ -55,7 +55,7 @@ contract('Accountant Contract Implementation tests', ([txMaker, operatorAddress,
     it("should register and initialize accountant", async () => {
         await registry.registerAccountant(operator.address, 10, 0, OneToken)
         const accountantId = await registry.getAccountantAddress(operator.address)
-        expect(await registry.isActiveAccountant(accountantId)).to.be.true
+        expect(await registry.isAccountant(accountantId)).to.be.true
 
         // Initialise accountant object
         accountant = await AccountantImplementation.at(accountantId)

--- a/test/accountantClosing.js
+++ b/test/accountantClosing.js
@@ -46,7 +46,7 @@ contract('Accountant closing', ([txMaker, operatorAddress, ...beneficiaries]) =>
         await registry.registerAccountant(accountantOperator.address, stake, Zero, OneToken)
         const accountantId = await registry.getAccountantAddress(accountantOperator.address)
         accountant = await AccountantImplementation.at(accountantId)
-        expect(await registry.isActiveAccountant(accountant.address)).to.be.true
+        expect(await registry.isAccountant(accountant.address)).to.be.true
     })
 
     it('should be able to close accountant', async () => {

--- a/test/accountantClosing.js
+++ b/test/accountantClosing.js
@@ -26,7 +26,7 @@ const provider = wallet.generateAccount()
 const operatorPrivKey = Buffer.from('d6dd47ec61ae1e85224cec41885eec757aa77d518f8c26933e5d9f0cda92f3c3', 'hex')
 const accountantOperator = wallet.generateAccount(operatorPrivKey)
 
-contract.only('Accountant closing', ([txMaker, operatorAddress, ...beneficiaries]) => {
+contract('Accountant closing', ([txMaker, operatorAddress, ...beneficiaries]) => {
     let token, accountant, registry, stake
     before(async () => {
         stake = OneToken

--- a/test/accountantClosing.js
+++ b/test/accountantClosing.js
@@ -1,0 +1,85 @@
+require('chai')
+.use(require('chai-as-promised'))
+.should()
+const { BN } = require('openzeppelin-test-helpers')
+const { randomBytes } = require('crypto')
+
+const { topUpTokens, generateChannelId, keccak } = require('./utils/index.js')
+const { 
+    signIdentityRegistration,
+    signChannelBalanceUpdate,
+    signChannelLoanReturnRequest,
+    createPromise
+} = require('./utils/client.js')
+const wallet = require('./utils/wallet.js')
+
+const MystToken = artifacts.require("MystToken")
+const MystDex = artifacts.require("MystDEX")
+const Registry = artifacts.require("Registry")
+const AccountantImplementation = artifacts.require("TestAccountantImplementation")
+const ChannelImplementation = artifacts.require("ChannelImplementation")
+
+const OneToken = web3.utils.toWei(new BN('100000000'), 'wei')
+const Zero = new BN(0)
+
+const provider = wallet.generateAccount()
+const operatorPrivKey = Buffer.from('d6dd47ec61ae1e85224cec41885eec757aa77d518f8c26933e5d9f0cda92f3c3', 'hex')
+const accountantOperator = wallet.generateAccount(operatorPrivKey)
+
+contract.only('Accountant closing', ([txMaker, operatorAddress, ...beneficiaries]) => {
+    let token, accountant, registry, stake
+    before(async () => {
+        stake = OneToken
+
+        token = await MystToken.new()
+        const dex = await MystDex.new()
+        const accountantImplementation = await AccountantImplementation.new(token.address, accountantOperator.address, 0, OneToken)
+        const channelImplementation = await ChannelImplementation.new()
+        registry = await Registry.new(token.address, dex.address, channelImplementation.address, accountantImplementation.address, Zero, stake)
+
+        // Topup some tokens into txMaker address so it could register accountant
+        await topUpTokens(token, txMaker, OneToken)
+        await token.approve(registry.address, OneToken)
+    })
+
+    it('should register accountant', async () => {
+        await registry.registerAccountant(accountantOperator.address, stake, Zero, OneToken)
+        const accountantId = await registry.getAccountantAddress(accountantOperator.address)
+        accountant = await AccountantImplementation.at(accountantId)
+        expect(await registry.isActiveAccountant(accountant.address)).to.be.true
+    })
+
+    it('should be able to close accountant', async () => {
+        const initialBalance = await token.balanceOf(accountant.address)
+        expect((await accountant.getStatus()).toNumber()).to.be.equal(0)  // 0 - Active, 1 - Paused, 2 - Punishment, 3 - Closed
+        await accountant.closeAccountant({from: operatorAddress})
+        expect((await accountant.getStatus()).toNumber()).to.be.equal(3)  // 0 - Active, 1 - Paused, 2 - Punishment, 3 - Closed
+        const currentBalance = await token.balanceOf(accountant.address)
+        initialBalance.should.be.bignumber.equal(currentBalance)
+    })
+
+    it('should fail getting stake back until timelock passes', async () => {
+        const expectedBlockNumber = (await web3.eth.getBlock('latest')).number + 4
+        expect((await web3.eth.getBlock('latest')).number).to.be.below(expectedBlockNumber)
+        await accountant.getStakeBack(beneficiaries[0], {from: operatorAddress}).should.be.rejected
+    })
+
+    it('should allow to get stake back after timelock passes', async () => {
+        const initialAccountantBalance = await token.balanceOf(accountant.address)
+        const expectedBlockNumber = (await web3.eth.getBlock('latest')).number + 4
+
+        // Move blockchain forward
+        for (let i=0; i<5; i++) {
+            await accountant.moveBlock()
+        }
+        expect((await web3.eth.getBlock('latest')).number).to.be.above(expectedBlockNumber)
+
+        await accountant.getStakeBack(beneficiaries[0], {from: operatorAddress})
+
+        const currentAccountantBalance = await token.balanceOf(accountant.address)
+        const beneficiaryBalance = await token.balanceOf(beneficiaries[0])
+        beneficiaryBalance.should.be.bignumber.equal(initialAccountantBalance)
+        currentAccountantBalance.should.be.bignumber.equal(Zero)
+    })
+
+})

--- a/test/accountantFee.js
+++ b/test/accountantFee.js
@@ -45,13 +45,13 @@ contract('Accountant fee', ([txMaker, operatorAddress, ...beneficiaries]) => {
         accountant = await AccountantImplementation.at(accountantId)
 
         // Fee of settling one token should be 0.025 token
-        const oneTokenSettleFee = await accountant.getAccountantFee(OneToken)
+        const oneTokenSettleFee = await accountant.calculateAccountantFee(OneToken)
         let fee = oneTokenSettleFee / OneToken
         expect(fee).to.be.equal(0.025)
 
         // When settling sumer small values, we'll round fee to avoid calculation errors or value overflow
         const smallValueToSettle = new BN(100)  // 0.000000000000000100 token
-        fee = await accountant.getAccountantFee(smallValueToSettle)
+        fee = await accountant.calculateAccountantFee(smallValueToSettle)
         fee.should.be.bignumber.equal(new BN(3))
     })
 
@@ -90,7 +90,7 @@ contract('Accountant fee', ([txMaker, operatorAddress, ...beneficiaries]) => {
         const promise = createPromise(channelId, amount, Zero, hashlock, accountantOperator)
 
         // Calculate expected accountant fee
-        const fee = await accountant.getAccountantFee(amount)
+        const fee = await accountant.calculateAccountantFee(amount)
 
         // Settle promise
         const initialAccountantBalance = await token.balanceOf(accountant.address)
@@ -124,7 +124,7 @@ contract('Accountant fee', ([txMaker, operatorAddress, ...beneficiaries]) => {
     })
 
     it('should still calculate previous fee value untill validFrom block not arrived', async () => {
-        const oneTokenSettleFee = await accountant.getAccountantFee(OneToken)
+        const oneTokenSettleFee = await accountant.calculateAccountantFee(OneToken)
         let fee = oneTokenSettleFee / OneToken
         expect(fee).to.be.equal(0.025)
     })
@@ -140,7 +140,7 @@ contract('Accountant fee', ([txMaker, operatorAddress, ...beneficiaries]) => {
             await accountant.moveBlock()
         }
 
-        const oneTokenSettleFee = await accountant.getAccountantFee(OneToken)
+        const oneTokenSettleFee = await accountant.calculateAccountantFee(OneToken)
         fee = oneTokenSettleFee / OneToken
         expect(fee).to.be.equal(0.0175)
     })

--- a/test/accountantPunishment.js
+++ b/test/accountantPunishment.js
@@ -47,7 +47,7 @@ contract('Accountant punishment', ([txMaker, operatorAddress, ...beneficiaries])
         await registry.registerAccountant(accountantOperator.address, stake, Zero, OneToken)
         const accountantId = await registry.getAccountantAddress(accountantOperator.address)
         accountant = await AccountantImplementation.at(accountantId)
-        expect(await registry.isActiveAccountant(accountant.address)).to.be.true
+        expect(await registry.isAccountant(accountant.address)).to.be.true
     })
 
     it('should open provider channel and calculate zero available balance', async () => {
@@ -236,3 +236,5 @@ contract('Accountant punishment', ([txMaker, operatorAddress, ...beneficiaries])
         expect(await accountant.isAccountantActive()).to.be.true
     })
 })
+
+// TODO add tests when emergency not resolved on time

--- a/test/accountantStake.js
+++ b/test/accountantStake.js
@@ -51,7 +51,7 @@ contract('Accountant stake', ([txMaker, operatorAddress, ...beneficiaries]) => {
         await registry.registerAccountant(accountantOperator.address, stake, Zero, OneToken)
         const accountantId = await registry.getAccountantAddress(accountantOperator.address)
         accountant = await AccountantImplementation.at(accountantId)
-        expect(await registry.isActiveAccountant(accountant.address)).to.be.true
+        expect(await registry.isAccountant(accountant.address)).to.be.true
     })
 
     it('should open provider channel and calculate zero available balance', async () => {

--- a/test/contracts/TestAccountantImplementation.sol
+++ b/test/contracts/TestAccountantImplementation.sol
@@ -15,7 +15,11 @@ contract TestAccountantImplementation is AccountantImplementation {
     function getTimelock() internal view returns (uint256) {
         return block.number + DELAY_BLOCKS;
     }
-    
+
+    function getEmergencyTimelock() internal view returns (uint256) {
+        return block.number + DELAY_BLOCKS;
+    }
+
     function getNow() public view returns (uint256) {
         return now;
     }

--- a/test/greenpaths.js
+++ b/test/greenpaths.js
@@ -67,7 +67,7 @@ contract('Green path tests', ([txMaker, ...beneficiaries]) => {
     it("register and initialize accountant", async () => {
         await registry.registerAccountant(operator.address, 10, 0, OneToken)
         const accountantId = await registry.getAccountantAddress(operator.address)
-        expect(await registry.isActiveAccountant(accountantId)).to.be.true
+        expect(await registry.isAccountant(accountantId)).to.be.true
 
         // Initialise accountant object
         accountant = await AccountantImplementation.at(accountantId)

--- a/test/multiAccountants.js
+++ b/test/multiAccountants.js
@@ -44,7 +44,7 @@ contract('Multi accountants', ([txMaker, ...beneficiaries]) => {
             await registry.registerAccountant(operator.address, 10, 0, OneToken)
             const id = await registry.getAccountantAddress(operator.address)
             accountants.push({id, operator})
-            expect(await registry.isActiveAccountant(id)).to.be.true
+            expect(await registry.isAccountant(id)).to.be.true
         }
     })
 

--- a/test/registry.js
+++ b/test/registry.js
@@ -46,7 +46,7 @@ contract('Registry', ([txMaker, minter, accountantOperator, fundsDestination, ..
     it('should register accountant', async () => {
         await registry.registerAccountant(accountantOperator, 10, 0, OneToken)
         accountantId = await registry.getAccountantAddress(accountantOperator)
-        expect(await registry.isActiveAccountant(accountantId)).to.be.true
+        expect(await registry.isAccountant(accountantId)).to.be.true
     })
 
     it('should register identity having 0 balance', async () => {


### PR DESCRIPTION
- Unified `setBeneficiary()` with other similar calls
- Renamed `getAccountantFee` into `calculateAccountantFee`
- Added functionality for Accountant to get his stake after closing activity and waiting for timelock to pass
- Added protection from reply attack for `setFundsDestinationByCheque()` 
- Deleted some not actionable TODOs
- `isActiveAccountant()` is now internal function to avoid unwanted reverts

