### PR TITLE
We don't need miniStake anymore

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -148,7 +148,7 @@ contract Registry is FundsRecovery, Utils {
         return address(_channel);
     }
 
-    function registerHermes(address _hermesOperator, uint256 _hermesStake, uint16 _hermesFee, uint256 _minChannelStake, uint256 _maxChannelStake, bytes memory _url) public {
+    function registerHermes(address _hermesOperator, uint256 _hermesStake, uint16 _hermesFee, uint256 _maxChannelStake, bytes memory _url) public {
         require(isInitialized(), "Registry: only initialized registry can register hermeses");
         require(_hermesOperator != address(0), "Registry: hermes operator can't be zero address");
         require(_hermesStake >= minimalHermesStake, "Registry: hermes have to stake at least minimal stake amount");
@@ -163,7 +163,7 @@ contract Registry is FundsRecovery, Utils {
         token.transferFrom(msg.sender, address(_hermes), _hermesStake);
 
         // Initialise hermes
-        _hermes.initialize(address(token), _hermesOperator, _hermesFee, _minChannelStake, _maxChannelStake, dex);
+        _hermes.initialize(address(token), _hermesOperator, _hermesFee, _maxChannelStake, dex);
 
         // Save info about newly created hermes
         hermeses[_hermesId] = Hermes(_hermesOperator, getLastImplVer(), _hermes.getStake, _url);

--- a/contracts/interfaces/IHermesContract.sol
+++ b/contracts/interfaces/IHermesContract.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.6;
 
 interface IHermesContract {
     enum Status { Active, Paused, Punishment, Closed }
-    function initialize(address _token, address _operator, uint16 _hermesFee, uint256 _minStake, uint256 _maxStake, address payable _routerAddress) external;
+    function initialize(address _token, address _operator, uint16 _hermesFee, uint256 _maxStake, address payable _routerAddress) external;
     function openChannel(address _party, uint256 _amountToLend) external;
     function getOperator() external view returns (address);
     function getStake() external view returns (uint256);

--- a/test/beneficiary.js
+++ b/test/beneficiary.js
@@ -3,7 +3,7 @@
     Tested functions can be found in smart-contract code at `contracts/HermesImplementation.sol`.
 */
 
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const {
     generateChannelId,
     topUpTokens,
@@ -42,7 +42,7 @@ contract("Setting beneficiary tests", ([txMaker, operatorAddress, beneficiaryA, 
         token = await MystToken.new()
         const dex = await setupDEX(token, txMaker)
         const hermesImplementation = await HermesImplementation.new()
-        await hermesImplementation.initialize(token.address, operator.address, 0, 0, OneToken, dex.address)
+        await hermesImplementation.initialize(token.address, operator.address, 0, OneToken, dex.address)
         const channelImplementation = await ChannelImplementation.new()
 
         registry = await Registry.new()
@@ -57,7 +57,7 @@ contract("Setting beneficiary tests", ([txMaker, operatorAddress, beneficiaryA, 
     })
 
     it("should register and initialize hermes hub", async () => {
-        await registry.registerHermes(operator.address, 10, 0, 25, OneToken, hermesURL)
+        await registry.registerHermes(operator.address, 10, 0, OneToken, hermesURL)
         const hermesId = await registry.getHermesAddress(operator.address)
         expect(await registry.isHermes(hermesId)).to.be.true
 

--- a/test/channel.js
+++ b/test/channel.js
@@ -3,7 +3,7 @@
     Smart-contract code can be found in `contracts/ChannelImplementation.sol`.
 */
 
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const {
     topUpTokens,
     topUpEthers,
@@ -30,7 +30,7 @@ contract('Channel Contract Implementation tests', ([txMaker, ...otherAccounts]) 
         token = await MystToken.new()
         const dex = await setupDEX(token, txMaker)
         hermesImplementation = await TestHermesImplementation.new()
-        await hermesImplementation.initialize(token.address, hermes.address, 0, 0, OneToken, dex.address)
+        await hermesImplementation.initialize(token.address, hermes.address, 0, OneToken, dex.address)
         channel = await TestChannelImplementation.new(token.address, dex.address, identityHash, hermesImplementation.address, Zero)
 
         // Give some ethers for gas for hermes

--- a/test/fastWithdrawal.js
+++ b/test/fastWithdrawal.js
@@ -3,7 +3,7 @@
     Smart-contract code can be found in `contracts/ChannelImplementation.sol`.
 */
 
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const {
     topUpTokens,
     topUpEthers,
@@ -30,7 +30,7 @@ contract('Fast withdrawal from consumer channel', ([txMaker, ...otherAccounts]) 
         token = await MystToken.new()
         const dex = await setupDEX(token, txMaker)
         hermesImplementation = await TestHermesImplementation.new()
-        await hermesImplementation.initialize(token.address, hermes.address, 0, 0, OneToken, dex.address)
+        await hermesImplementation.initialize(token.address, hermes.address, 0, OneToken, dex.address)
         channel = await TestChannelImplementation.new(token.address, dex.address, identityHash, hermesImplementation.address, Zero)
 
         // Give some ethers for gas for hermes and some tokens for channel

--- a/test/fundsRecovery.js
+++ b/test/fundsRecovery.js
@@ -1,4 +1,4 @@
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const {
     deriveContractAddress,
     topUpEthers,
@@ -203,7 +203,7 @@ contract('Hermes funds recovery', ([_, txMaker, account, fundsDestination, ...ot
 
         // Deploy Hermes smart contract
         hermesImplementation = await TestHermesImplementation.new({ from: txMaker })
-        await hermesImplementation.initialize(nativeToken.address, account, 0, 25, OneToken, dex.address)
+        await hermesImplementation.initialize(nativeToken.address, account, 0, OneToken, dex.address)
         expect(hermesImplementation.address.toLowerCase()).to.be.equal(implementationAddress.toLowerCase())
 
         // Set funds destination

--- a/test/fundsRecoveryByCheque.js
+++ b/test/fundsRecoveryByCheque.js
@@ -1,4 +1,4 @@
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const {
     genCreate2Address,
     signMessage,
@@ -66,7 +66,7 @@ contract('Full path (in channel using cheque) test for funds recovery', ([txMake
     })
 
     it('should register hermes', async () => {
-        await registry.registerHermes(hermesOperator, 10, 0, 25, OneEther, hermesURL)
+        await registry.registerHermes(hermesOperator, 10, 0, OneEther, hermesURL)
         expect(await registry.isHermes(hermesId)).to.be.true
     })
 

--- a/test/greenpaths.js
+++ b/test/greenpaths.js
@@ -3,7 +3,7 @@
     on-chain and off-chain interactions from registering identity, to settlement of received funds
 */
 
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const {
     topUpTokens,
     topUpEthers,
@@ -69,7 +69,7 @@ contract('Green path tests', ([txMaker, ...beneficiaries]) => {
 
     // Ask tx-maker to make tx +  sign cheque for him for that. Works even with registration fee stuff.
     it("register and initialize hermes", async () => {
-        await registry.registerHermes(operator.address, 10, 0, 25, OneToken, hermesURL)
+        await registry.registerHermes(operator.address, 10, 0, OneToken, hermesURL)
         const hermesId = await registry.getHermesAddress(operator.address)
         expect(await registry.isHermes(hermesId)).to.be.true
 
@@ -200,7 +200,7 @@ contract('Green path tests', ([txMaker, ...beneficiaries]) => {
     })
 
     it('should register second hermes', async () => {
-        await registry.registerHermes(operator2.address, 10, 0, 50, OneToken, hermes2URL)
+        await registry.registerHermes(operator2.address, 10, 0, OneToken, hermes2URL)
         const hermesId = await registry.getHermesAddress(operator2.address)
         expect(await registry.isHermes(hermesId)).to.be.true
 

--- a/test/hermes.js
+++ b/test/hermes.js
@@ -37,7 +37,6 @@ const ChainID = 1
 
 const operatorPrivKey = Buffer.from('d6dd47ec61ae1e85224cec41885eec757aa77d518f8c26933e5d9f0cda92f3c3', 'hex')
 
-const minStake = new BN(25)
 const maxStake = new BN(100000)
 
 contract('Hermes Contract Implementation tests', ([txMaker, operatorAddress, hermesOwner, beneficiaryA, beneficiaryB, beneficiaryC, beneficiaryD, ...otherAccounts]) => {
@@ -65,7 +64,7 @@ contract('Hermes Contract Implementation tests', ([txMaker, operatorAddress, her
     })
 
     it("should register and initialize hermes", async () => {
-        await registry.registerHermes(operator.address, 10, 0, minStake, maxStake, hermesURL)
+        await registry.registerHermes(operator.address, 10, 0, maxStake, hermesURL)
         const hermesId = await registry.getHermesAddress(operator.address)
         expect(await registry.isHermes(hermesId)).to.be.true
 
@@ -443,21 +442,6 @@ contract('Hermes Contract Implementation tests', ([txMaker, operatorAddress, her
         await hermes.withdraw(beneficiary, amount).should.be.rejected
 
         initialBalance.should.be.bignumber.equal(await token.balanceOf(hermes.address))
-    })
-
-    it("hermes owner should be able to set new minStake", async () => {
-        const stakeBefore = (await hermes.getStakeThresholds())[0]
-        const newMinStake = 321
-        await hermes.setMinStake(newMinStake, { from: hermesOwner })
-
-        const stakeAfter = (await hermes.getStakeThresholds())[0]
-        expect(stakeBefore.toNumber()).to.be.equal(25)
-        expect(stakeAfter.toNumber()).to.be.equal(321)
-    })
-
-    it("not hermes owner should be not able to set new minStake", async () => {
-        const newMinStake = 1
-        await hermes.setMinStake(newMinStake).should.be.rejected
     })
 
     it("hermes owner should be able to set new maxStake", async () => {

--- a/test/hermesChannelSettlement.js
+++ b/test/hermesChannelSettlement.js
@@ -4,7 +4,7 @@
 */
 
 // const {BN} = require('web3-utils')
-const {BN} = require('web3-utils');
+const { BN } = require('web3-utils');
 // const { randomBytes } = require('crypto')
 const {
     generateChannelId,
@@ -40,7 +40,6 @@ const hermesURL = Buffer.from('http://test.hermes')
 const operator = wallet.generateAccount(Buffer.from('d6dd47ec61ae1e85224cec41885eec757aa77d518f8c26933e5d9f0cda92f3c3', 'hex'))  // Generate hermes operator wallet
 const providerA = wallet.generateAccount()
 
-const minStake = new BN(25)
 const maxStake = new BN(50000)
 
 contract("Channel openinig via settlement tests", ([txMaker, beneficiaryA, beneficiaryB, beneficiaryC, ...otherAccounts]) => {
@@ -62,7 +61,7 @@ contract("Channel openinig via settlement tests", ([txMaker, beneficiaryA, benef
     })
 
     it("should register and initialize hermes hub", async () => {
-        await registry.registerHermes(operator.address, 100000, Zero, minStake, maxStake, hermesURL)
+        await registry.registerHermes(operator.address, 100000, Zero, maxStake, hermesURL)
         const hermesId = await registry.getHermesAddress(operator.address)
         expect(await registry.isHermes(hermesId)).to.be.true
 
@@ -95,8 +94,8 @@ contract("Channel openinig via settlement tests", ([txMaker, beneficiaryA, benef
         const promise = generatePromise(amountToPay, Zero, channelState, operator, providerA.address)
         var res = await hermes.settleWithBeneficiary(promise.identity, promise.amount, promise.fee, promise.lock, promise.signature, beneficiaryA, beneficiaryChangeSignature)
 
-        assertEvent(res, 'PromiseSettled',{"lock":"0x"+promise.lock.toString('hex')})
-        
+        assertEvent(res, 'PromiseSettled', { "lock": "0x" + promise.lock.toString('hex') })
+
         const balanceAfter = await token.balanceOf(beneficiaryA)
         balanceAfter.should.be.bignumber.equal(balanceBefore.add(amountToPay))
 
@@ -117,9 +116,9 @@ contract("Channel openinig via settlement tests", ([txMaker, beneficiaryA, benef
 
         // Generate and settle promise
         const promise = generatePromise(amountToPay, Zero, channelState, operator, providerA.address)
-        var res =await hermes.settlePromise(promise.identity, promise.amount, promise.fee, promise.lock, promise.signature)
+        var res = await hermes.settlePromise(promise.identity, promise.amount, promise.fee, promise.lock, promise.signature)
 
-        assertEvent(res, 'PromiseSettled',{"lock":"0x"+promise.lock.toString('hex')})
+        assertEvent(res, 'PromiseSettled', { "lock": "0x" + promise.lock.toString('hex') })
 
         // Promise can settle even more than its stake (up to maxStake)
         const balanceAfter = await token.balanceOf(beneficiaryA)
@@ -143,7 +142,7 @@ contract("Channel openinig via settlement tests", ([txMaker, beneficiaryA, benef
 
             let res = await hermes.settlePromise(promise.identity, promise.amount, promise.fee, promise.lock, promise.signature)
 
-            assertEvent(res, 'PromiseSettled',{"lock":"0x"+promise.lock.toString('hex')})
+            assertEvent(res, 'PromiseSettled', { "lock": "0x" + promise.lock.toString('hex') })
 
             const balanceAfter = await token.balanceOf(beneficiaryA)
             balanceAfter.should.be.bignumber.equal(balanceBefore.add(maxStake))
@@ -165,7 +164,7 @@ contract("Channel openinig via settlement tests", ([txMaker, beneficiaryA, benef
         const promise = generatePromise(amountToPay, transactorFee, channelState, operator, providerA.address)
         var res = await hermes.settleIntoStake(promise.identity, promise.amount, promise.fee, promise.lock, promise.signature)
 
-        assertEvent(res, 'PromiseSettled',{"lock":"0x"+promise.lock.toString('hex')})
+        assertEvent(res, 'PromiseSettled', { "lock": "0x" + promise.lock.toString('hex') })
 
         // It should have increased stake
         const channelStakeAfter = (await hermes.channels(channelId)).stake

--- a/test/hermesClosing.js
+++ b/test/hermesClosing.js
@@ -1,7 +1,7 @@
 require('chai')
     .use(require('chai-as-promised'))
     .should()
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 
 const { topUpTokens, setupDEX, sleep } = require('./utils/index.js')
 const {
@@ -43,7 +43,7 @@ contract('Hermes closing', ([txMaker, operatorAddress, ...beneficiaries]) => {
     })
 
     it('should register hermes', async () => {
-        await registry.registerHermes(hermesOperator.address, stake, Zero, 25, OneToken, hermesURL)
+        await registry.registerHermes(hermesOperator.address, stake, Zero, OneToken, hermesURL)
         const hermesId = await registry.getHermesAddress(hermesOperator.address)
         hermes = await HermesImplementation.at(hermesId)
         expect(await registry.isHermes(hermes.address)).to.be.true

--- a/test/hermesFee.js
+++ b/test/hermesFee.js
@@ -1,7 +1,7 @@
 require('chai')
     .use(require('chai-as-promised'))
     .should()
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const { randomBytes } = require('crypto')
 const { topUpTokens, generateChannelId, keccak, setupDEX, sleep } = require('./utils/index.js')
 const {
@@ -43,7 +43,7 @@ contract('Hermes fee', ([txMaker, operatorAddress, ...beneficiaries]) => {
     it('should calculate proper fee righ after hermes registration', async () => {
         // Register hermes
         const hermesFee = 250 // 2.50%
-        await registry.registerHermes(hermesOperator.address, 100, hermesFee, 25, OneToken, hermesURL)
+        await registry.registerHermes(hermesOperator.address, 100, hermesFee, OneToken, hermesURL)
         const hermesId = await registry.getHermesAddress(hermesOperator.address)
         hermes = await HermesImplementation.at(hermesId)
 

--- a/test/hermesPayAndSettle.js
+++ b/test/hermesPayAndSettle.js
@@ -1,4 +1,4 @@
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const chai = require('chai')
 chai.use(require('chai-as-promised'))
 chai.use(require('chai-bn')(BN))
@@ -36,8 +36,6 @@ const provider = wallet.generateAccount()
 const operatorPrivKey = Buffer.from('d6dd47ec61ae1e85224cec41885eec757aa77d518f8c26933e5d9f0cda92f3c3', 'hex')
 const hermesOperator = wallet.generateAccount(operatorPrivKey)
 const hermesFee = new BN('1000') // hermes takes 10%
-
-const minStake = new BN(25)
 const maxStake = new BN(1000000)
 
 
@@ -57,7 +55,7 @@ contract('Pay and settle', ([txMaker, operatorAddress, ...otherAccounts]) => {
     })
 
     it("should register and initialize hermes", async () => {
-        await registry.registerHermes(operatorAddress, OneToken, hermesFee, minStake, maxStake, hermesURL)
+        await registry.registerHermes(operatorAddress, OneToken, hermesFee, maxStake, hermesURL)
         const hermesId = await registry.getHermesAddress(operatorAddress)
         expect(await registry.isHermes(hermesId)).to.be.true
 

--- a/test/hermesStakeAndPunishment.js
+++ b/test/hermesStakeAndPunishment.js
@@ -1,7 +1,7 @@
 require('chai')
     .use(require('chai-as-promised'))
     .should()
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const { randomBytes } = require('crypto')
 
 const { topUpTokens, setupDEX, generateChannelId, keccak, sleep } = require('./utils/index.js')
@@ -53,7 +53,7 @@ contract('Hermes stake and punishment management', ([txMaker, operatorAddress, .
     })
 
     it('should register hermes when stake is ok', async () => {
-        await registry.registerHermes(hermesOperator.address, stake, Zero, 25, OneToken, hermesURL)
+        await registry.registerHermes(hermesOperator.address, stake, Zero, OneToken, hermesURL)
         const hermesId = await registry.getHermesAddress(hermesOperator.address)
         hermes = await HermesImplementation.at(hermesId)
         expect(await registry.isHermes(hermes.address)).to.be.true

--- a/test/multiHermes.js
+++ b/test/multiHermes.js
@@ -1,7 +1,7 @@
 require('chai')
     .use(require('chai-as-promised'))
     .should()
-const {BN} = require('web3-utils')
+const { BN } = require('web3-utils')
 const { topUpTokens, setupDEX } = require('./utils/index.js')
 const { signIdentityRegistration } = require('./utils/client.js')
 const wallet = require('./utils/wallet.js')
@@ -43,7 +43,7 @@ contract('Multi hermeses', ([txMaker, ...beneficiaries]) => {
     it('should register hermeses', async () => {
         hermeses = []
         for (const operator of operators) {
-            await registry.registerHermes(operator.address, 10, 0, 25, OneToken, hermesURL)
+            await registry.registerHermes(operator.address, 10, 0, OneToken, hermesURL)
             const id = await registry.getHermesAddress(operator.address)
             hermeses.push({ id, operator })
             expect(await registry.isHermes(id)).to.be.true

--- a/test/registry.js
+++ b/test/registry.js
@@ -66,7 +66,7 @@ contract('Deterministic registry', ([txMaker, ...otherAccounts]) => {
     })
 
     it('should have hermes implementation deployed into deterministic address', async () => {
-        const expectedAddress = '0x3D32855ba8889E07e9942894CCA6f799bb6E321f'
+        const expectedAddress = '0x4D011fe99Ffb30b6b1D501b815AcadC8534A5Edf'
         expect(await registry.getHermesImplementation()).to.be.equal(expectedAddress)
     })
 })
@@ -89,7 +89,7 @@ contract('Registry', ([txMaker, minter, fundsDestination, ...otherAccounts]) => 
 
     it('should register hermes', async () => {
         const hermesURL = Buffer.from('http://test.hermes')
-        await registry.registerHermes(hermesOperator, 10, 0, 25, OneToken, hermesURL)
+        await registry.registerHermes(hermesOperator, 10, 0, OneToken, hermesURL)
         hermesId = await registry.getHermesAddress(hermesOperator)
         expect(await registry.isHermes(hermesId)).to.be.true
     })
@@ -227,21 +227,21 @@ contract('Registry', ([txMaker, minter, fundsDestination, ...otherAccounts]) => 
 
     it("should be able to register hermes for previously unknown operator", async () => {
         const hermesURL = Buffer.from('http://test.hermes')
-        await registry.registerHermes(hermesOperator2, 10, 0, 25, OneToken, hermesURL)
+        await registry.registerHermes(hermesOperator2, 10, 0, OneToken, hermesURL)
         hermes2Id = await registry.getHermesAddress(hermesOperator2)
         expect(await registry.isHermes(hermes2Id)).to.be.true
     })
 
     it("same operator should be able to register second hermes with new implementations", async () => {
         const hermesURL = Buffer.from('http://test.hermes')
-        await registry.registerHermes(hermesOperator, 10, 0, 25, OneToken, hermesURL)
+        await registry.registerHermes(hermesOperator, 10, 0, OneToken, hermesURL)
         hermes3Id = await registry.getHermesAddress(hermesOperator)
         expect(await registry.isHermes(hermes3Id)).to.be.true
     })
 
     it("should fail to register one more hermes with same implementation", async () => {
         const hermesURL = Buffer.from('http://test2.hermes')
-        await registry.registerHermes(hermesOperator, 10, 0, 25, OneToken, hermesURL).should.be.rejected
+        await registry.registerHermes(hermesOperator, 10, 0, OneToken, hermesURL).should.be.rejected
     })
 
     it('should register identity with v2 channel', async () => {
@@ -305,7 +305,7 @@ contract('Registry', ([txMaker, minter, fundsDestination, ...otherAccounts]) => 
             url: Buffer.from('http://test.hermes'),
         }
 
-        await registry.registerHermes(hermes.operator.address, 10, 0, 25, OneToken, hermes.url)
+        await registry.registerHermes(hermes.operator.address, 10, 0, OneToken, hermes.url)
         hermes.identity = await registry.getHermesAddress(hermes.operator.address)
         expect(await registry.isHermes(hermes.identity)).to.be.true
 


### PR DESCRIPTION
This is alternative to #141 in case we would decide that playing with minStake is not worth it. Also #141 has one bad thing, it is stake per hermes, so user will need to stake into all hermesses who would ask for `minStake`. Implementation without `minStake` is more user friendly. We may need to find another "skin in the game" protection mechanism though.